### PR TITLE
Google Mapsでルート表示機能を実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,24 +4,53 @@ import InputForm from '@/components/organisms/InputForm';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { z } from "zod";
+import Modal from '@/components/atoms/Modal';
+
+interface PlanCandidate {
+  content: {
+    parts: {
+      text: string;
+    }[];
+  };
+}
+
+interface Plan {
+  candidates: PlanCandidate[];
+}
+
+interface PlanResponse {
+  plan: Plan;
+}
+
+interface FormData {
+  departure: string;
+  time?: string;
+  transport?: string;
+  mood?: string;
+  customTime?: string;
+}
 
 export default function Home() {
-  const [plan, setPlan] = useState<any>(null);
+  const [plan, setPlan] = useState<PlanResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [formData, setFormData] = useState<any>(null);
+  const [formData, setFormData] = useState<FormData | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handlePlanSubmit = async (formData: any) => {
+  const handlePlanSubmit = async (formData: FormData | null) => {
+    if (!formData) return;
+
     setIsLoading(true);
+    setIsModalOpen(false);
     setFormData(formData);
     try {
-      const { distance, spotType, ...filteredFormData } = formData;
       const schema = z.object({
         departure: z.string().min(1, { message: "出発地を入力してください" }),
-        time: z.string(),
-        transport: z.string(),
+        time: z.string().optional(),
+        transport: z.string().optional(),
         mood: z.string().optional(),
+        customTime: z.string().optional(),
       });
-      const validatedData = schema.parse(filteredFormData);
+      const validatedData = schema.parse(formData);
 
       const response = await fetch('/api/plan', {
         method: 'POST',
@@ -32,12 +61,13 @@ export default function Home() {
       });
 
       if (response.ok) {
-        const data = await response.json();
+        const data = await response.json() as PlanResponse;
         setPlan(data);
+        setIsModalOpen(true);
       } else {
         console.error('Error:', response.status);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (error instanceof z.ZodError) {
         const errorMessage = error.errors.map((e) => e.message).join(', ');
         console.error('バリデーションエラー:', errorMessage);
@@ -50,23 +80,56 @@ export default function Home() {
     }
   };
 
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const planText = plan?.plan?.candidates?.[0]?.content?.parts?.[0]?.text || "";
+const spotName = planText.split('\n')[0] || "";
+const departure = formData?.departure || "";
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4">
-      <h1 className="text-4xl font-bold mb-4">Random Trip Planner</h1>
+    <div className="flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-8">Random Trip Planner</h1>
       <InputForm onSubmit={handlePlanSubmit} isLoading={isLoading} />
-      {isLoading && <p>プランを作成中です...</p>}
-      {plan && plan.plan && plan.plan.candidates && plan.plan.candidates[0] && plan.plan.candidates[0].content && plan.plan.candidates[0].content.parts && plan.plan.candidates[0].content.parts[0].text && (
-        <div className="mt-8 p-4 border rounded-md">
-          <h2 className="text-2xl font-bold mb-2">提案プラン</h2>
-          <ReactMarkdown>{plan.plan.candidates[0].content.parts[0].text}</ReactMarkdown>
-          <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed" onClick={() => handlePlanSubmit(formData)} disabled={isLoading}>別のプランを提案</button>
-          <button className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed" onClick={() => {
-            const spotName = plan.plan.candidates[0].content.parts[0].text.split('\n')[0];
-            const url = `https://www.google.com/maps/search?q=${spotName}`;
-            window.open(url, '_blank');
-          }} disabled={isLoading}>地図で見る</button>
-        </div>
-      )}
+      {isLoading && <p className="mt-4">プランを作成中です...</p>}
+      <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
+        {plan?.plan?.candidates?.[0]?.content?.parts?.[0]?.text && (
+          <div className="mt-8 p-4 border rounded-md w-full">
+            <h2 className="text-2xl font-bold mb-2">提案プラン</h2>
+            <div className="prose dark:prose-invert max-w-none">
+              <ReactMarkdown
+                components={{
+                  h1: ({...props}) => <h1 className="text-2xl font-bold mb-4 mt-0" {...props} />,
+                  h2: ({...props}) => <h2 className="text-xl font-semibold mb-3 mt-6" {...props} />,
+                  ul: ({...props}) => <ul className="list-disc pl-6 mb-4 space-y-2" {...props} />,
+                  ol: ({...props}) => <ol className="list-decimal pl-6 mb-4 space-y-2" {...props} />,
+                  li: ({...props}) => <li className="text-base" {...props} />,
+                  p: ({...props}) => <p className="mb-4 leading-relaxed" {...props} />
+                }}
+              >
+                {plan.plan.candidates[0].content.parts[0].text}
+              </ReactMarkdown>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-4 mt-6 justify-center">
+              <button
+                className="w-full sm:w-auto bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                onClick={() => handlePlanSubmit(formData)}
+                disabled={isLoading || !formData}
+              >
+                別のプランを提案
+              </button>
+              <button
+                className="w-full sm:w-auto bg-green-500 hover:bg-green-700 text-white font-bold py-3 px-6 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                onClick={() => window.open(`https://www.google.com/maps/dir/${encodeURIComponent(departure)}/${encodeURIComponent(spotName)}`, '_blank')}
+                disabled={isLoading || !spotName.trim() || !departure.trim()}
+              >
+                地図で見る
+              </button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## 変更内容

- 地図で見るボタンクリック時に、出発地から目的地までのルートをGoogle Maps上に表示
- Google Maps URLスキーマを使用してルート表示を実現（APIキー不要）
- 出発地・目的地が未入力の場合はボタンを無効化

## 確認項目
- [ ] 地図で見るボタンをクリックすると、新しいタブでGoogle Mapsが開く
- [ ] 出発地から目的地までのルートが表示される
- [ ] 出発地か目的地が未入力の場合、ボタンが無効化される